### PR TITLE
Allow response to contains extra field in its claim

### DIFF
--- a/src/Vanilla/VanillaConnect/VanillaConnectProvider.php
+++ b/src/Vanilla/VanillaConnect/VanillaConnectProvider.php
@@ -50,6 +50,8 @@ class VanillaConnectProvider {
      * @param string $clientID
      * @param string $secret
      * @param array $redirectURLsWhitelist
+     *
+     * @throws \Exception
      */
     public function __construct($clientID, $secret, array $redirectURLsWhitelist) {
         $this->vanillaConnect = new VanillaConnect($clientID, $secret);

--- a/tests/VanillaTest/VanillaConnect/VanillaConnectRequestTest.php
+++ b/tests/VanillaTest/VanillaConnect/VanillaConnectRequestTest.php
@@ -15,13 +15,13 @@ class VanillaConnectRequestTest extends TestCase {
     /**
      * @var VanillaConnect
      */
-    private static $vanillaConnect;
+    private $vanillaConnect;
 
     /**
      * {@inheritdoc}
      */
-    public static function setupBeforeClass() {
-        self::$vanillaConnect = new VanillaConnect('TestClientID', 'TestSecret');
+    public function setUp() {
+        $this->vanillaConnect = new VanillaConnect('TestClientID', 'TestSecret');
     }
 
     /**
@@ -30,9 +30,9 @@ class VanillaConnectRequestTest extends TestCase {
     public function testRequest() {
         $jti = uniqid();
         $state = ['a' => 'yay', 'b' => 'yup'];
-        $jwt = self::$vanillaConnect->createRequestAuthJWT($jti, $state);
+        $jwt = $this->vanillaConnect->createRequestAuthJWT($jti, $state);
 
-        $this->assertTrue(self::$vanillaConnect->validateRequest($jwt, $claim));
+        $this->assertTrue($this->vanillaConnect->validateRequest($jwt, $claim));
 
         $this->assertTrue(is_array($claim));
         $this->assertArrayHasKey('jti', $claim);

--- a/tests/VanillaTest/VanillaConnect/VanillaConnectResponseTest.php
+++ b/tests/VanillaTest/VanillaConnect/VanillaConnectResponseTest.php
@@ -15,13 +15,13 @@ class VanillaConnectResponseTest extends TestCase {
     /**
      * @var VanillaConnect
      */
-    private static $vanillaConnect;
+    private $vanillaConnect;
 
     /**
      * {@inheritdoc}
      */
-    public static function setupBeforeClass() {
-        self::$vanillaConnect = new VanillaConnect('TestClientID', 'TestSecret');
+    public function setUp() {
+        $this->vanillaConnect = new VanillaConnect('TestClientID', 'TestSecret');
     }
 
     /**
@@ -30,12 +30,30 @@ class VanillaConnectResponseTest extends TestCase {
     public function testResponse() {
         $jti = uniqid();
         $id = uniqid();
-        $jwt = self::$vanillaConnect->createResponseAuthJWT($jti, ['id' => $id]);
+        $jwt = $this->vanillaConnect->createResponseAuthJWT($jti, ['id' => $id]);
 
-        $this->assertTrue(self::$vanillaConnect->validateResponse($jwt, $claim));
+        $this->assertTrue($this->vanillaConnect->validateResponse($jwt, $claim));
 
         $this->assertTrue(is_array($claim));
         $this->assertArrayHasKey('jti', $claim);
         $this->assertEquals($jti, $claim['jti']);
+    }
+
+    /**
+     * Test that it is possible to add extra data in the response claim.
+     *
+     * @throws \Exception
+     */
+    public function testExtraInfo() {
+        $jti = uniqid();
+        $id = uniqid();
+        $userData = ['email' => 'test@example.com', 'name' => 'test'];
+        $jwt = $this->vanillaConnect->createResponseAuthJWT($jti, ['id' => $id, 'user' => $userData]);
+
+        $this->assertTrue($this->vanillaConnect->validateResponse($jwt, $claim));
+
+        $extractedUserData = VanillaConnect::extractItemFromClaim($jwt, 'user');
+
+        $this->assertEquals($userData, $extractedUserData);
     }
 }


### PR DESCRIPTION
The response was filtered which made it impossible to pass proper user information.
This also adds extra validation to `createResponseAuthJWT()` which can now throw an exception if the claim is missing required fields.